### PR TITLE
Change COMBINING DOUBLE INVERTED BREVE accent marks

### DIFF
--- a/rarebooks/30804005653604.xml
+++ b/rarebooks/30804005653604.xml
@@ -3,7 +3,7 @@
 <dcterms:provenance>Virginia Museum of Fine Arts Library</dcterms:provenance>
 <dcterms:type>Text</dcterms:type>
 <dcterms:temporal>Nineteenth century</dcterms:temporal>
-<dcterms:creator>Ėkspedit︠s︡ii︠a︡ zagotovlenii︠a︡ gosudarstvennykh bumag (Russia)</dcterms:creator>
+<dcterms:creator>Ėkspedit͡sii͡a zagotovlenii͡a gosudarstvennykh bumag (Russia)</dcterms:creator>
 <dcterms:identifier>30804005653604</dcterms:identifier>
 <dcterms:extent>[2], 65, [3] pages, [27] leaves of plates : illustrations, portraits, plans ; 68 cm</dcterms:extent>
 <dcterms:created>1883</dcterms:created>
@@ -16,5 +16,5 @@
 <dcterms:subject>Coronations</dcterms:subject>
 <dcterms:medium>Chromolithographs</dcterms:medium>
 <dcterms:subject>Alexander, Emperor of Russia, III, 1845-1894</dcterms:subject>
-<dcterms:subject>Marīi︠a︡ Ḟeodorovna, Empress, consort of Alexander III, Emperor of Russia, 1847-1928</dcterms:subject>
+<dcterms:subject>Marīi͡a Ḟeodorovna, Empress, consort of Alexander III, Emperor of Russia, 1847-1928</dcterms:subject>
 </mdRecord>

--- a/rarebooks/30804005653661.xml
+++ b/rarebooks/30804005653661.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mdRecord xmlns="http://dplava.lib.virginia.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xsi:schemaLocation="http://dplava.lib.virginia.edu/dplava.xsd"><dcterms:title>Skazka o t︠s︡ari︠e︡ Saltani︠e︡, o syni︠e︡ ego slavnom i moguchem bogatyri︠e︡, kni︠a︡zi︠e︡ Gvidoni︠e︡ Saltanovichi︠e︡, i o prekrasnoĭ t︠s︡arevni︠e︡ Lebedi / risunki I.A. Bilibina.</dcterms:title>
+<mdRecord xmlns="http://dplava.lib.virginia.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xsi:schemaLocation="http://dplava.lib.virginia.edu/dplava.xsd"><dcterms:title>Skazka o t͡sari͡e Saltani͡e, o syni͡e ego slavnom i moguchem bogatyri͡e, kni͡azi͡e Gvidoni͡e Saltanovichi͡e, i o prekrasnoĭ t͡sarevni͡e Lebedi / risunki I.A. Bilibina.</dcterms:title>
 <dcterms:provenance>Virginia Museum of Fine Arts Library</dcterms:provenance>
 <dcterms:type>Text</dcterms:type>
 <dcterms:temporal>Twentieth century</dcterms:temporal>
 <dcterms:creator>Pushkin, Aleksandr Sergeevich, 1799-1837.</dcterms:creator>
-<dcterms:creator>Bilibin, Ivan I︠A︡kovlevich, 1876-1942.</dcterms:creator>
+<dcterms:creator>Bilibin, Ivan I͡Akovlevich, 1876-1942.</dcterms:creator>
 <dcterms:identifier>30804005653661</dcterms:identifier>
 <dcterms:extent>20 pages : color illustrations ; 25 x 33 cm</dcterms:extent>
 <dcterms:created>1905</dcterms:created>
 <dcterms:language>rus</dcterms:language>
 <edm:isShownAt>https://www.vmfa.museum/piction/108734640-124109645/</edm:isShownAt>
 <edm:preview>https://vmfa-assets.nyc3.digitaloceanspaces.com/uploads/2019/11/124109651.jpg</edm:preview>
-<dcterms:publisher>St. Petersburg, Russia : Izdanīe Ėkspedit︠s︡īi zagotovlenīi︠a︡ gosudarstvennykh bumag</dcterms:publisher>
+<dcterms:publisher>St. Petersburg, Russia : Izdanīe Ėkspedit͡sīi zagotovlenīi͡a gosudarstvennykh bumag</dcterms:publisher>
 <dcterms:rights>https://rightsstatements.org/vocab/NoC-US/1.0/</dcterms:rights>
-<dcterms:subject>Skazka o t︠s︡are Saltane</dcterms:subject>
+<dcterms:subject>Skazka o t͡sare Saltane</dcterms:subject>
 <dcterms:subject>Children's literature, Russian.</dcterms:subject>
 <dcterms:subject>Folk literature.</dcterms:subject>
 <dcterms:medium>Illustrated children's books.</dcterms:medium>

--- a/rarebooks/30804005661334.xml
+++ b/rarebooks/30804005661334.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mdRecord xmlns="http://dplava.lib.virginia.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xsi:schemaLocation="http://dplava.lib.virginia.edu/dplava.xsd"><dcterms:title>T︠S︡arevna-li︠a︡gushka / risunki I.I︠A︡. Bilibina.</dcterms:title>
+<mdRecord xmlns="http://dplava.lib.virginia.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xsi:schemaLocation="http://dplava.lib.virginia.edu/dplava.xsd"><dcterms:title>T͡Sarevna-li͡agushka / risunki I.I͡A. Bilibina.</dcterms:title>
 <dcterms:provenance>Virginia Museum of Fine Arts Library</dcterms:provenance>
 <dcterms:type>Text</dcterms:type>
 <dcterms:temporal>Twentieth century</dcterms:temporal>
 <dcterms:creator>Afanasʹev, A. N. (Aleksandr Nikolaevich), 1826-1871.</dcterms:creator>
-<dcterms:creator>Bilibin, Ivan I︠A︡kovlevich, 1876-1942.</dcterms:creator>
-<dcterms:creator>Ėkspedit︠s︡ii︠a︡ zagotovlenii︠a︡ gosudarstvennykh bumag (Russia)</dcterms:creator>
+<dcterms:creator>Bilibin, Ivan I͡Akovlevich, 1876-1942.</dcterms:creator>
+<dcterms:creator>Ėkspedit͡sii͡a zagotovlenii͡a gosudarstvennykh bumag (Russia)</dcterms:creator>
 <dcterms:identifier>30804005661334</dcterms:identifier>
 <dcterms:extent>12 pages : color illustrations ; 33 cm</dcterms:extent>
 <dcterms:created>1901</dcterms:created><dcterms:language>rus</dcterms:language><edm:isShownAt>https://www.vmfa.museum/piction/108734640-200710539/</edm:isShownAt>
 <edm:preview>https://vmfa-assets.nyc3.digitaloceanspaces.com/uploads/2019/11/200710545.jpg</edm:preview>
-<dcterms:publisher>St. Petersburg, Russia : Izdanīe Ėkspedit︠s︡īi zagotovlenīi︠a︡ gosudarstvennykh bumag</dcterms:publisher>
+<dcterms:publisher>St. Petersburg, Russia : Izdanīe Ėkspedit͡sīi zagotovlenīi͡a gosudarstvennykh bumag</dcterms:publisher>
 <dcterms:rights>https://rightsstatements.org/vocab/NoC-US/1.0/</dcterms:rights>
 <dcterms:subject>Children's literature, Russian.</dcterms:subject>
 <dcterms:subject>Folk literature.</dcterms:subject>

--- a/rarebooks/30804005661433.xml
+++ b/rarebooks/30804005661433.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mdRecord xmlns="http://dplava.lib.virginia.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xsi:schemaLocation="http://dplava.lib.virginia.edu/dplava.xsd">
-<dcterms:title>Marʹi︠a︡ Morevna / risunki I.I︠A︡. Bilibina.</dcterms:title>
+<dcterms:title>Marʹi͡a Morevna / risunki I.I͡A. Bilibina.</dcterms:title>
 <dcterms:provenance>Virginia Museum of Fine Arts Library</dcterms:provenance>
 <dcterms:type>Text</dcterms:type>
 <dcterms:temporal>Twentieth century</dcterms:temporal>
-<dcterms:creator>Bilibin, Ivan I︠A︡kovlevich, 1876-1942.</dcterms:creator>
-<dcterms:creator>Ėkspedit︠s︡ii︠a︡ zagotovlenii︠a︡ gosudarstvennykh bumag (Russia)</dcterms:creator>
+<dcterms:creator>Bilibin, Ivan I͡Akovlevich, 1876-1942.</dcterms:creator>
+<dcterms:creator>Ėkspedit͡sii͡a zagotovlenii͡a gosudarstvennykh bumag (Russia)</dcterms:creator>
 <dcterms:identifier>30804005661433</dcterms:identifier>
 <dcterms:extent>12 pages : color illustrations ; 33 cm</dcterms:extent>
 <dcterms:created>1903</dcterms:created><dcterms:language>rus</dcterms:language><edm:isShownAt>https://www.vmfa.museum/piction/108734640-200711614/</edm:isShownAt>
 <edm:preview>https://vmfa-assets.nyc3.digitaloceanspaces.com/uploads/2019/11/200711620.jpg</edm:preview>
-<dcterms:publisher>St. Petersburg, Russia : Izdanīe Ėkspedit︠s︡īi zagotovlenīi︠a︡ gosudarstvennykh bumag</dcterms:publisher>
+<dcterms:publisher>St. Petersburg, Russia : Izdanīe Ėkspedit͡sīi zagotovlenīi͡a gosudarstvennykh bumag</dcterms:publisher>
 <dcterms:rights>https://rightsstatements.org/vocab/NoC-US/1.0/</dcterms:rights>
 <dcterms:subject>Children's literature, Russian.</dcterms:subject>
 <dcterms:subject>Folk literature.</dcterms:subject>

--- a/rarebooks/30804005661680.xml
+++ b/rarebooks/30804005661680.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mdRecord xmlns="http://dplava.lib.virginia.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xsi:schemaLocation="http://dplava.lib.virginia.edu/dplava.xsd"><dcterms:title>Skazka ob Ivani︠e︡-tsarevichi︠e︡, Zhar-ptit︠s︡i︠e︡ i o si︠e︡rom volki︠e︡ / risunki I. I︠A︡. Bilibina.</dcterms:title>
+<mdRecord xmlns="http://dplava.lib.virginia.edu" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xsi:schemaLocation="http://dplava.lib.virginia.edu/dplava.xsd"><dcterms:title>Skazka ob Ivani͡e-tsarevichi͡e, Zhar-ptit͡si͡e i o si͡erom volki͡e / risunki I. I͡A. Bilibina.</dcterms:title>
 <dcterms:provenance>Virginia Museum of Fine Arts Library</dcterms:provenance>
 <dcterms:type>Text</dcterms:type>
 <dcterms:temporal>Twentieth century</dcterms:temporal>
-<dcterms:creator>Bilibin, Ivan I︠A︡kovlevich, 1876-1942.</dcterms:creator>
-<dcterms:creator>Ėkspedit︠s︡ii︠a︡ zagotovlenii︠a︡ gosudarstvennykh bumag (Russia)</dcterms:creator>
+<dcterms:creator>Bilibin, Ivan I͡Akovlevich, 1876-1942.</dcterms:creator>
+<dcterms:creator>Ėkspedit͡sii͡a zagotovlenii͡a gosudarstvennykh bumag (Russia)</dcterms:creator>
 <dcterms:identifier>30804005661680</dcterms:identifier>
 <dcterms:extent>12 pages : color illustrations ; 33 cm</dcterms:extent>
 <dcterms:created>1901</dcterms:created><dcterms:language>rus</dcterms:language><edm:isShownAt>https://www.vmfa.museum/piction/108734640-165748563/</edm:isShownAt>
 <edm:preview>https://vmfa-assets.nyc3.digitaloceanspaces.com/uploads/2019/11/165748570.jpg</edm:preview>
-<dcterms:publisher>St. Petersburg, Russia : Izdanīe Ėkspedit︠s︡īi zagotovlenīi︠a︡ gosudarstvennykh bumag</dcterms:publisher>
+<dcterms:publisher>St. Petersburg, Russia : Izdanīe Ėkspedit͡sīi zagotovlenīi͡a gosudarstvennykh bumag</dcterms:publisher>
 <dcterms:rights>https://rightsstatements.org/vocab/NoC-US/1.0/</dcterms:rights>
 <dcterms:subject>Children's literature, Russian.</dcterms:subject>
 <dcterms:subject>Folk literature.</dcterms:subject>


### PR DESCRIPTION
Change the representation of the COMBINING DOUBLE INVERTED BREVE from char1 U+FE20 char2 U+FE21 with two normal width accent marks to char1 U+0361 char2 because the graphic representation of the double width accent mark is more likely to exist in fonts